### PR TITLE
keybroker: support the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,18 @@ authors = ["Stefano Garzarella <sgarzare@redhat.com>"]
 
 [features]
 default = [ "std", "keybroker" ]
-alloc = [ "base64ct/alloc", "hex/alloc", "kbs-types/alloc", "kbs-types-reference-kbs?/alloc", "serde/alloc", "serde_json/alloc" ]
-std = [ "base64ct/std", "hex/std", "kbs-types/std", "kbs-types-reference-kbs?/std", "serde/std", "serde_json/std" ]
+alloc = [ "base64ct/alloc", "hex/alloc", "kbs-types/alloc", "serde/alloc", "serde_json/alloc" ]
+std = [ "base64ct/std", "hex/std", "kbs-types/std", "serde/std", "serde_json/std" ]
 all_clients = [ "keybroker", "reference_kbs" ]
-keybroker = []
-reference_kbs = [ "dep:kbs-types-reference-kbs" ]
+keybroker = [ "dep:kbs-types" ]
+reference_kbs = [ "dep:kbs-types" ]
 
 [dependencies]
 anyhow = { version = "1.0.75", default-features = false }
 base64ct = { version = "1.6.0", default-features = false }
 hex = { version = "0.4", default-features = false }
 #kbs-types = { version = "0.5.0", default-features = false }
-kbs-types = { git = "https://github.com/tylerfanelli/kbs-types", branch = "snp_mods", default-features = false, features = ["tee-snp"] }
-kbs-types-reference-kbs = { package = "kbs-types", git = "https://github.com/virtee/kbs-types", rev = "5a9b4df73e7", default-features = false, features = ["tee-snp"], optional = true }
+kbs-types = { git = "https://github.com/virtee/kbs-types", rev = "5a9b4df73e7", default-features = false, features = ["tee-snp"], optional = true }
 num-bigint = { version = "0.8", default-features = false, package = "num-bigint-dig" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
@@ -34,7 +33,6 @@ rsa = "0.9.3"
 sha2 = "0.10.8"
 sev = { version = "2.0", default-features = false, features = ["snp"] }
 thiserror = "1.0.50"
-uuid = { version = "1.5.0", features = ["serde"] }
 
 [[example]]
 name = "svsm-register"

--- a/examples/keybroker/data/policy.rego
+++ b/examples/keybroker/data/policy.rego
@@ -1,0 +1,3 @@
+package policy
+
+default allow = true

--- a/examples/keybroker/data/queries.json
+++ b/examples/keybroker/data/queries.json
@@ -1,0 +1,1 @@
+["data.measurement == input.measurement"]

--- a/examples/keybroker/data/resources.json
+++ b/examples/keybroker/data/resources.json
@@ -1,0 +1,1 @@
+{"passphrase":"mysecretpassphrase"}

--- a/src/clients/reference_kbs.rs
+++ b/src/clients/reference_kbs.rs
@@ -1,4 +1,4 @@
-use kbs_types_reference_kbs::{SnpAttestation, SnpRequest};
+use kbs_types::{SnpAttestation, SnpRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 


### PR DESCRIPTION
This commit is based on Tyler's PR:
https://github.com/stefano-garzarella/reference-kbc/pull/4

The rebase of multi-client support was tricky, so I backported only the necessary changes.

I made a few changes (avoided openssl dependency, etc.), but keybroker functionality should be preserved.

Co-developed-by: Tyler Fanelli <tfanelli@redhat.com>